### PR TITLE
Initialize HBase for Dataproc HA

### DIFF
--- a/hbase/hbase.sh
+++ b/hbase/hbase.sh
@@ -103,7 +103,7 @@ EOF
   local hbase_root_dir="$(/usr/share/google/get_metadata_value attributes/hbase-root-dir)"
   if [[ -z "${hbase_root_dir}" ]]; then
     if [[ "${MASTER_ADDITIONAL}" != "" ]]; then
-      hbase_root_dir="hdfs://${CLUSTER_NAME}-m-0:8020/hbase"
+      hbase_root_dir="hdfs://${CLUSTER_NAME}:8020/hbase"
     else
       hbase_root_dir="hdfs://${CLUSTER_NAME}-m:8020/hbase"
     fi


### PR DESCRIPTION
The current hbase configuration tries to connect the first namenode in Dataproc. It leads to hbase master down when the first namenode  is shutdown or restarted.

To fix this, `hbase.rootDir` should use the value of `fs.defaultFS` in hadoop configuration.